### PR TITLE
Fix alert fade

### DIFF
--- a/playlist_management/static/css/add_songs.css
+++ b/playlist_management/static/css/add_songs.css
@@ -85,3 +85,7 @@ hr {
     opacity: 0;
     transition: 2s linear;
 }
+
+.show {
+    opacity: 1;
+}

--- a/playlist_management/static/js/add_songs.js
+++ b/playlist_management/static/js/add_songs.js
@@ -21,9 +21,10 @@ function getCookie(c_name)
 }
 
 function songAddedAlert(msg) {
-    $('#song-added-alert').toggleClass('hidden');
+    var toggle = () => $('#song-added-alert').toggleClass('show');
+    toggle();
     setTimeout(function(){
-        $("#song-added-alert").toggleClass('hidden');
+        toggle()
     }, 2000);
 }
 


### PR DESCRIPTION
Fair warning: this is untested since I didn't feel like getting this all running on my computer. You may also want to strip out that arrow function (i.e  `() => val` vs `function () { return val }` since it can cause issues in older browsers.